### PR TITLE
Remove open/close button from natural tab order, refs. #16

### DIFF
--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
@@ -468,6 +468,7 @@ export class AdgComboboxComponent {
           <button
             class="adg-combobox--toggle-options-button"
             type="button"
+            tabindex="-1"
             onClick={() => this.handleToggleOptionsButtonClicked()}
           >
             <img


### PR DESCRIPTION
To save a `Tab` key press, the "Open/close" button is removed from natural tab order, using `tabindex="-1"`. Keyboards can still open/close the dropdown by pressing `Up`/`Down` key.

Screen readers can still find the button and interact with it.

See https://github.com/NothingAG/adg-components/issues/16#issuecomment-1108581686. Closes #16.