### PR TITLE
Add filtering tests (for both single and multi)

### DIFF
--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -107,6 +107,7 @@ export const expectMultiCombobox = async (
   await expectCombobox(adgCombobox, mergedExpectations, {
     internalId: internalId,
     label: 'Hobbies',
+    filterLabel: 'Hobbies',
     multi: true,
     lang: 'en',
   });

--- a/tests/multiselect.spec.ts
+++ b/tests/multiselect.spec.ts
@@ -453,12 +453,28 @@ test.describe('ADG-Combobox (multi)', () => {
         focusedOption: 'Badminton',
       });
 
-      await page.keyboard.press('a'); // Add "d", so filter is "ba", and focus should be back on filter input
-      test.fixme(); // Focus is not put back to filter input
+      await page.keyboard.press('d'); // Add "d", so filter is "ad", and focus should be back on filter input
       await expectMultiCombobox(page, {
         filterFocused: true,
-        filterValue: 'ba',
-        visibleOptions: ['Badminton'],
+        filterValue: 'ad',
+        visibleOptions: ['Badminton', 'Reading'],
+        optionsExpanded: true,
+      });
+
+      await page.keyboard.press('ArrowDown'); // Move focus to first option "Badminton"
+      await page.keyboard.press('ArrowDown'); // Move focus to next option "Reading"
+      await expectMultiCombobox(page, {
+        filterValue: 'ad',
+        visibleOptions: ['Badminton', 'Reading'],
+        optionsExpanded: true,
+        focusedOption: 'Reading',
+      });
+
+      await page.keyboard.press('x'); // Add "x", so filter is "adx", and focus should be back on filter input
+      await expectMultiCombobox(page, {
+        filterFocused: true,
+        filterValue: 'adx',
+        visibleOptions: [],
         optionsExpanded: true,
       });
     });

--- a/tests/singleselect.spec.ts
+++ b/tests/singleselect.spec.ts
@@ -334,7 +334,7 @@ test.describe('ADG-Combobox (single)', () => {
     });
   });
 
-  test.describe.skip('Filter', () => {
+  test.describe('Filter', () => {
     test('Change filter term to expand options', async ({ page }) => {
       await tabIntoFilter(page, 'coloursCombobox'); // Focus filter term (does not expand options)
       await expectSingleCombobox(page, {
@@ -346,7 +346,7 @@ test.describe('ADG-Combobox (single)', () => {
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'b',
-        visibleOptions: ['Blue', 'Kickboxing'],
+        visibleOptions: ['Black', 'Blue', 'Brown'],
         optionsExpanded: true,
       });
     });
@@ -357,22 +357,22 @@ test.describe('ADG-Combobox (single)', () => {
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'b',
-        visibleOptions: ['Blue', 'Kickboxing'],
+        visibleOptions: ['Black', 'Blue', 'Brown'],
         optionsExpanded: true,
       });
 
-      await page.keyboard.press('a'); // Add "a", so filter is "ba"
+      await page.keyboard.press('l'); // Add "a", so filter is "bl"
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'ba',
-        visibleOptions: ['Blue'],
+        visibleOptions: ['Black', 'Blue'],
         optionsExpanded: true,
       });
 
-      await page.keyboard.press('t'); // Add "t", so filter is "bat"
+      await page.keyboard.press('x'); // Add "x", so filter is "blx"
       await expectSingleCombobox(page, {
         filterFocused: true,
-        filterValue: 'bat',
+        filterValue: 'blx',
         visibleOptions: [],
         optionsExpanded: true,
       });
@@ -384,23 +384,24 @@ test.describe('ADG-Combobox (single)', () => {
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'b',
-        visibleOptions: ['Blue', 'Kickboxing'],
+        visibleOptions: ['Black', 'Blue', 'Brown'],
         optionsExpanded: true,
       });
 
-      await page.keyboard.press('ArrowDown'); // Move focus to first option "Blue"
+      await page.keyboard.press('ArrowDown'); // Move focus to first option "Black"
       await expectSingleCombobox(page, {
         filterValue: 'b',
-        visibleOptions: ['Blue', 'Kickboxing'],
-        focusedOption: 'Blue',
+        visibleOptions: ['Black', 'Blue', 'Brown'],
+        focusedOption: 'Black',
         optionsExpanded: true,
       });
 
-      await page.keyboard.press('ArrowDown'); // Move focus to next (last) option "Kickboxing"
+      await page.keyboard.press('ArrowDown'); // Move focus to next option "Blue"
+      await page.keyboard.press('ArrowDown'); // Move focus to next (last) option "Brown"
       await expectSingleCombobox(page, {
         filterValue: 'b',
-        visibleOptions: ['Blue', 'Kickboxing'],
-        focusedOption: 'Kickboxing',
+        visibleOptions: ['Black', 'Blue', 'Brown'],
+        focusedOption: 'Brown',
         optionsExpanded: true,
       });
 
@@ -408,7 +409,7 @@ test.describe('ADG-Combobox (single)', () => {
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'b',
-        visibleOptions: ['Blue', 'Kickboxing'],
+        visibleOptions: ['Black', 'Blue', 'Brown'],
         optionsExpanded: true,
       });
     });
@@ -417,42 +418,43 @@ test.describe('ADG-Combobox (single)', () => {
       page,
     }) => {
       await clickIntoFilter(page, 'coloursCombobox'); // Expand options
-      await page.keyboard.press('a'); // Start filtering with "a"
+      await page.keyboard.press('l'); // Start filtering with "a"
       await expectSingleCombobox(page, {
         filterFocused: true,
-        filterValue: 'a',
-        visibleOptions: [
-          'Blue',
-          'Green',
-          'Dancing',
-          'Painting',
-          'Reading',
-          'Programming',
-        ],
+        filterValue: 'l',
+        visibleOptions: ['Black', 'Blue', 'Yellow'],
         optionsExpanded: true,
       });
 
-      await page.keyboard.press('ArrowDown'); // Move focus to first option "Blue"
+      await page.keyboard.press('ArrowDown'); // Move focus to first option "Black"
       await expectSingleCombobox(page, {
-        filterValue: 'a',
-        visibleOptions: [
-          'Blue',
-          'Green',
-          'Dancing',
-          'Painting',
-          'Reading',
-          'Programming',
-        ],
+        filterValue: 'l',
+        visibleOptions: ['Black', 'Blue', 'Yellow'],
         optionsExpanded: true,
-        focusedOption: 'Blue',
+        focusedOption: 'Black',
       });
 
-      await page.keyboard.press('a'); // Add "d", so filter is "ba", and focus should be back on filter input
-      test.fixme(); // Focus is not put back to filter input
+      await page.keyboard.press('a'); // Add "a", so filter is "la", and focus should be back on filter input
       await expectSingleCombobox(page, {
         filterFocused: true,
-        filterValue: 'ba',
-        visibleOptions: ['Blue'],
+        filterValue: 'la',
+        visibleOptions: ['Black'],
+        optionsExpanded: true,
+      });
+
+      await page.keyboard.press('ArrowDown'); // Move focus to first option "Black"
+      await expectSingleCombobox(page, {
+        filterValue: 'la',
+        visibleOptions: ['Black'],
+        optionsExpanded: true,
+        focusedOption: 'Black',
+      });
+
+      await page.keyboard.press('x'); // Add "x", so filter is "lax", and focus should be back on filter input
+      await expectSingleCombobox(page, {
+        filterFocused: true,
+        filterValue: 'lax',
+        visibleOptions: [],
         optionsExpanded: true,
       });
     });


### PR DESCRIPTION
Thanks to @rudigier fixing #33 and #34, I could get all pre-written tests work, for both single and multi select. 🍾😊🎉

![CleanShot 2022-04-30 at 07 25 14@2x](https://user-images.githubusercontent.com/1814983/166092612-cef21c57-a0b0-4b9d-b173-af1adce8cd32.png)

I think that with this we have reached a solid foundation where we can add/change functionality of the component without risking too many regressions. This will be of great help for @wmaurer to fix some of the issues that are still open.

Admitted, the test code is quite ugly still, but it works very well. 💪 Playwright is pretty cool, I'd say! Thanks for choosing it, @ramonwenger!