### PR TITLE
Refactor tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ It is based on HTML form controls, with which we prove that **accessibility is s
 <script nomodule src="/build/adg-components.js"></script>
 
 <adg-combobox
-  id="hobbiesCombobox"
+  id="hobbies"
   name="hobbies"
   label="Hobbies"
   lang="de"
 ></adg-combobox>
 
 <script>
-  const hobbiesCombobox = document.querySelector('#hobbiesCombobox');
-  hobbiesCombobox.formControlName = 'hobbies';
-  hobbiesCombobox.filterLabel = 'Hobbies';
-  hobbiesCombobox.options = [
+  const hobbies = document.querySelector('#hobbies');
+  hobbies.formControlName = 'hobbies';
+  hobbies.filterLabel = 'Hobbies';
+  hobbies.options = [
     'Soccer',
     'Badminton',
     'Movies',

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.i18n.de.json
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.i18n.de.json
@@ -1,10 +1,10 @@
 {
-  "input_placeholder": "Eingabe Suchbegriff",
+  "input_placeholder": "Suchbegriff eingeben",
   "close": "$(filterLabel) Auswahl schliessen",
   "open": "$(filterLabel) Auswahl öffnen",
   "results_title": "Verfügbare $(filterLabel)",
   "results": "$(optionsTotal) $(filterLabel)",
   "results_selected": "$(filterLabel) gewählt: ",
   "results_filtered": "$(optionsShown) von $(optionsTotal) $(filterLabel) für Filter \"$(filterTerm)\"",
-  "results_first": "erstes Resultat \"$(first)\""
+  "results_first": "beginnend mit \"$(first)\""
 }

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
@@ -82,6 +82,7 @@ export class AdgComboboxComponent {
       checked: false,
       hidden: false,
     }));
+    this.filteredOptionsStartingWith = this.optionModels[0].label;
   }
 
   @State() optionModels: OptionModel[] = [];
@@ -322,7 +323,7 @@ export class AdgComboboxComponent {
       // namely the instructions. We append them with a little delay so each
       // and every screen reader realises that the live region was changed and
       // hence needs to be announced.
-      this.showInstructions = true;
+      // this.showInstructions = true;
     }, 200);
   }
 

--- a/packages/adg-components/src/index.html
+++ b/packages/adg-components/src/index.html
@@ -36,9 +36,9 @@
     <hr />
 
     <form action="/" method="get">
-      <adg-combobox id="hobbiesCombobox" name="hobbies"></adg-combobox>
+      <adg-combobox id="hobbies" name="hobbies"></adg-combobox>
       <br />
-      <adg-combobox id="coloursCombobox" label="Farbe wählen" filterLabel="Colours" name="colours" lang="de"></adg-combobox>
+      <adg-combobox id="colours" label="Farben" filterLabel="Colours" name="colours" lang="de"></adg-combobox>
       <button type="submit">submit</button>
     </form>
 
@@ -49,10 +49,10 @@
     </p>
 
     <script>
-      const hobbiesCombobox = document.querySelector('#hobbiesCombobox');
-      hobbiesCombobox.multi = true;
-      hobbiesCombobox.label = 'Hobbies';
-      hobbiesCombobox.options = [
+      const hobbies = document.querySelector('#hobbies');
+      hobbies.multi = true;
+      hobbies.label = 'Hobbies';
+      hobbies.options = [
         'Soccer',
         'Badminton',
         'Movies',
@@ -66,8 +66,8 @@
         'Sleeping',
         'Programming',
       ];
-      const coloursCombobox = document.querySelector('#coloursCombobox');
-      coloursCombobox.options = [
+      const colours = document.querySelector('#colours');
+      colours.options = [
         {value: '000000', label: 'Black'},
         {value: '0000FF', label: 'Blue'},
         {value: 'A52A2A', label: 'Brown'},

--- a/tests/multiselect.spec.ts
+++ b/tests/multiselect.spec.ts
@@ -20,7 +20,7 @@ test.describe('ADG-Combobox (multi)', () => {
 
   test.describe('Keyboard interaction', () => {
     test('Tab into filter input', async ({ page }) => {
-      await tabIntoFilter(page, 'hobbiesCombobox');
+      await tabIntoFilter(page, 'hobbies');
       await expectMultiCombobox(page, {
         filterFocused: true,
         optionsExpanded: false,
@@ -28,7 +28,7 @@ test.describe('ADG-Combobox (multi)', () => {
     });
 
     test('Tab out of filter input', async ({ page }) => {
-      await tabIntoFilter(page, 'hobbiesCombobox');
+      await tabIntoFilter(page, 'hobbies');
       await expectMultiCombobox(page, {
         filterFocused: true,
         optionsExpanded: false,
@@ -44,7 +44,7 @@ test.describe('ADG-Combobox (multi)', () => {
     test('Toggle downwards through options using Down key', async ({
       page,
     }) => {
-      await tabIntoFilter(page, 'hobbiesCombobox');
+      await tabIntoFilter(page, 'hobbies');
       await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
       await expectMultiCombobox(page, {
         filterFocused: true,
@@ -87,7 +87,7 @@ test.describe('ADG-Combobox (multi)', () => {
     });
 
     test('Toggle upwards through options using Up key', async ({ page }) => {
-      await tabIntoFilter(page, 'hobbiesCombobox');
+      await tabIntoFilter(page, 'hobbies');
       await page.keyboard.press('ArrowUp'); // Press `Up` to expand options
       await expectMultiCombobox(page, {
         filterFocused: true,
@@ -131,7 +131,7 @@ test.describe('ADG-Combobox (multi)', () => {
 
     test.describe('Close options using Esc key', () => {
       test('When focus in filter input', async ({ page }) => {
-        await tabIntoFilter(page, 'hobbiesCombobox');
+        await tabIntoFilter(page, 'hobbies');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await expectMultiCombobox(page, {
           filterFocused: true,
@@ -147,7 +147,7 @@ test.describe('ADG-Combobox (multi)', () => {
       });
 
       test('When focus on option', async ({ page }) => {
-        await tabIntoFilter(page, 'hobbiesCombobox');
+        await tabIntoFilter(page, 'hobbies');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option
         await expectMultiCombobox(page, {
@@ -167,7 +167,7 @@ test.describe('ADG-Combobox (multi)', () => {
 
     test.describe('Select/unselect options', () => {
       test('Using Space key', async ({ page }) => {
-        await tabIntoFilter(page, 'hobbiesCombobox');
+        await tabIntoFilter(page, 'hobbies');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option "Soccer"
         await expectMultiCombobox(page, {
@@ -208,7 +208,7 @@ test.describe('ADG-Combobox (multi)', () => {
       });
 
       test('Using Enter key', async ({ page }) => {
-        await tabIntoFilter(page, 'hobbiesCombobox');
+        await tabIntoFilter(page, 'hobbies');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option "Soccer"
         await page.keyboard.press('Enter'); // Press `Enter` to check option "Soccer"
@@ -236,7 +236,7 @@ test.describe('ADG-Combobox (multi)', () => {
 
     test.describe('Activate "Unselect all" button', () => {
       test('"Unselect all" button', async ({ page }) => {
-        await tabIntoFilter(page, 'hobbiesCombobox');
+        await tabIntoFilter(page, 'hobbies');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option
         await page.keyboard.press('Space'); // Press `Space` to check option "Soccer"
@@ -264,7 +264,7 @@ test.describe('ADG-Combobox (multi)', () => {
     });
 
     test('Propagate Enter key', async ({ page }) => {
-      await tabIntoFilter(page, 'hobbiesCombobox');
+      await tabIntoFilter(page, 'hobbies');
       await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
       await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option
       await page.keyboard.press('Space'); // Press `Space` to check option "Soccer"
@@ -276,13 +276,13 @@ test.describe('ADG-Combobox (multi)', () => {
 
   test.describe('Mouse interaction', () => {
     test('Click into filter input', async ({ page }) => {
-      await clickIntoFilter(page, 'hobbiesCombobox'); // Click into the filter to expand options
+      await clickIntoFilter(page, 'hobbies'); // Click into the filter to expand options
       await expectMultiCombobox(page, {
         filterFocused: true,
         optionsExpanded: true,
       });
 
-      await clickIntoFilter(page, 'hobbiesCombobox'); // Click again into the filter, options remain expanded (unsure about that, see https://github.com/NothingAG/adg-components/issues/17)
+      await clickIntoFilter(page, 'hobbies'); // Click again into the filter, options remain expanded (unsure about that, see https://github.com/NothingAG/adg-components/issues/17)
       await expectMultiCombobox(page, {
         filterFocused: true,
         optionsExpanded: true,
@@ -290,7 +290,7 @@ test.describe('ADG-Combobox (multi)', () => {
     });
 
     test('Click out of filter input', async ({ page }) => {
-      await clickIntoFilter(page, 'hobbiesCombobox'); // Click into the filter to expand options
+      await clickIntoFilter(page, 'hobbies'); // Click into the filter to expand options
       await expectMultiCombobox(page, {
         filterFocused: true,
         optionsExpanded: true,
@@ -304,13 +304,13 @@ test.describe('ADG-Combobox (multi)', () => {
     });
 
     test('Click open/close button', async ({ page }) => {
-      await clickOpenCloseButton(page, 'hobbiesCombobox'); // Click open/close button to expand options
+      await clickOpenCloseButton(page, 'hobbies'); // Click open/close button to expand options
       await expectMultiCombobox(page, {
         filterFocused: true,
         optionsExpanded: true,
       });
 
-      await clickOpenCloseButton(page, 'hobbiesCombobox'); // Click open/close button to collapse options
+      await clickOpenCloseButton(page, 'hobbies'); // Click open/close button to collapse options
       await expectMultiCombobox(page, {
         filterFocused: true,
         optionsExpanded: false,
@@ -318,9 +318,9 @@ test.describe('ADG-Combobox (multi)', () => {
     });
 
     test('Select/unselect options', async ({ page }) => {
-      await clickIntoFilter(page, 'hobbiesCombobox'); // Expand options
-      await clickOption(page, 'Soccer', 'hobbiesCombobox'); // Select option "Soccer"
-      await clickOption(page, 'Movies', 'hobbiesCombobox'); // Select option "Movies"
+      await clickIntoFilter(page, 'hobbies'); // Expand options
+      await clickOption(page, 'Soccer', 'hobbies'); // Select option "Soccer"
+      await clickOption(page, 'Movies', 'hobbies'); // Select option "Movies"
       await expectMultiCombobox(page, {
         filterFocused: false,
         optionsExpanded: true,
@@ -329,7 +329,7 @@ test.describe('ADG-Combobox (multi)', () => {
         selectedOptions: ['Soccer', 'Movies'],
       });
 
-      await clickOption(page, 'Movies', 'hobbiesCombobox'); // Unselect option "Movies"
+      await clickOption(page, 'Movies', 'hobbies'); // Unselect option "Movies"
       await expectMultiCombobox(page, {
         filterFocused: false,
         visibleOptions: ALL_MULTI_OPTIONS.map((i) => i.label),
@@ -342,7 +342,7 @@ test.describe('ADG-Combobox (multi)', () => {
 
   test.describe('Filter', () => {
     test('Change filter term to expand options', async ({ page }) => {
-      await tabIntoFilter(page, 'hobbiesCombobox'); // Focus filter term (does not expand options)
+      await tabIntoFilter(page, 'hobbies'); // Focus filter term (does not expand options)
       await expectMultiCombobox(page, {
         filterFocused: true,
         optionsExpanded: false,
@@ -358,7 +358,7 @@ test.describe('ADG-Combobox (multi)', () => {
     });
 
     test('Enter term to filter options', async ({ page }) => {
-      await clickIntoFilter(page, 'hobbiesCombobox'); // Expand options
+      await clickIntoFilter(page, 'hobbies'); // Expand options
       await page.keyboard.press('b'); // Start filtering with "b"
       await expectMultiCombobox(page, {
         filterFocused: true,
@@ -385,7 +385,7 @@ test.describe('ADG-Combobox (multi)', () => {
     });
 
     test('Toggle through filtered options', async ({ page }) => {
-      await clickIntoFilter(page, 'hobbiesCombobox'); // Expand options
+      await clickIntoFilter(page, 'hobbies'); // Expand options
       await page.keyboard.press('b'); // Start filtering with "b"
       await expectMultiCombobox(page, {
         filterFocused: true,
@@ -422,7 +422,7 @@ test.describe('ADG-Combobox (multi)', () => {
     test('Filter can be changed while toggling through options', async ({
       page,
     }) => {
-      await clickIntoFilter(page, 'hobbiesCombobox'); // Expand options
+      await clickIntoFilter(page, 'hobbies'); // Expand options
       await page.keyboard.press('a'); // Start filtering with "a"
       await expectMultiCombobox(page, {
         filterFocused: true,

--- a/tests/singleselect.spec.ts
+++ b/tests/singleselect.spec.ts
@@ -21,7 +21,7 @@ test.describe('ADG-Combobox (single)', () => {
 
   test.describe('Keyboard interaction', () => {
     test('Tab into filter input', async ({ page }) => {
-      await tabIntoFilter(page, 'coloursCombobox');
+      await tabIntoFilter(page, 'colours');
       await expectSingleCombobox(page, {
         filterFocused: true,
         optionsExpanded: false,
@@ -29,7 +29,7 @@ test.describe('ADG-Combobox (single)', () => {
     });
 
     test('Tab out of filter input', async ({ page }) => {
-      await tabIntoFilter(page, 'coloursCombobox');
+      await tabIntoFilter(page, 'colours');
       await expectSingleCombobox(page, {
         filterFocused: true,
         optionsExpanded: false,
@@ -45,7 +45,7 @@ test.describe('ADG-Combobox (single)', () => {
     test('Toggle downwards through options using Down key', async ({
       page,
     }) => {
-      await tabIntoFilter(page, 'coloursCombobox');
+      await tabIntoFilter(page, 'colours');
       await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
       await expectSingleCombobox(page, {
         filterFocused: true,
@@ -88,7 +88,7 @@ test.describe('ADG-Combobox (single)', () => {
     });
 
     test('Toggle upwards through options using Up key', async ({ page }) => {
-      await tabIntoFilter(page, 'coloursCombobox');
+      await tabIntoFilter(page, 'colours');
       await page.keyboard.press('ArrowUp'); // Press `Up` to expand options
       await expectSingleCombobox(page, {
         filterFocused: true,
@@ -132,7 +132,7 @@ test.describe('ADG-Combobox (single)', () => {
 
     test.describe('Close options using Esc key', () => {
       test('When focus in filter input', async ({ page }) => {
-        await tabIntoFilter(page, 'coloursCombobox');
+        await tabIntoFilter(page, 'colours');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await expectSingleCombobox(page, {
           filterFocused: true,
@@ -148,7 +148,7 @@ test.describe('ADG-Combobox (single)', () => {
       });
 
       test('When focus on option', async ({ page }) => {
-        await tabIntoFilter(page, 'coloursCombobox');
+        await tabIntoFilter(page, 'colours');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option
         await expectSingleCombobox(page, {
@@ -168,7 +168,7 @@ test.describe('ADG-Combobox (single)', () => {
 
     test.describe('Select/unselect options', () => {
       test('Using Space key', async ({ page }) => {
-        await tabIntoFilter(page, 'coloursCombobox');
+        await tabIntoFilter(page, 'colours');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option "Black"
         await expectSingleCombobox(page, {
@@ -182,6 +182,7 @@ test.describe('ADG-Combobox (single)', () => {
         await expectSingleCombobox(page, {
           filterFocused: false,
           filterValue: 'Black',
+          filterTerm: '',
           visibleOptions: ALL_SINGLE_OPTIONS.map((i) => i.label),
           optionsExpanded: true,
           focusedOption: 'Black',
@@ -194,6 +195,7 @@ test.describe('ADG-Combobox (single)', () => {
         await expectSingleCombobox(page, {
           filterFocused: false,
           filterValue: 'Brown',
+          filterTerm: '',
           visibleOptions: ALL_SINGLE_OPTIONS.map((i) => i.label),
           optionsExpanded: true,
           focusedOption: 'Brown',
@@ -204,6 +206,7 @@ test.describe('ADG-Combobox (single)', () => {
         await expectSingleCombobox(page, {
           filterFocused: false,
           filterValue: 'Brown',
+          filterTerm: '',
           visibleOptions: ALL_SINGLE_OPTIONS.map((i) => i.label),
           optionsExpanded: true,
           focusedOption: 'Brown',
@@ -212,13 +215,14 @@ test.describe('ADG-Combobox (single)', () => {
       });
 
       test('Using Enter key', async ({ page }) => {
-        await tabIntoFilter(page, 'coloursCombobox');
+        await tabIntoFilter(page, 'colours');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option "Black"
         await page.keyboard.press('Enter'); // Press `Enter` to check option "Black"
         await expectSingleCombobox(page, {
           filterFocused: true,
           filterValue: 'Black',
+          filterTerm: '',
           visibleOptions: ALL_SINGLE_OPTIONS.map((i) => i.label),
           optionsExpanded: false,
           selectedOptions: ['Black'],
@@ -228,7 +232,7 @@ test.describe('ADG-Combobox (single)', () => {
 
     test.describe('Activate "Unselect all" button', () => {
       test('"Unselect all" button', async ({ page }) => {
-        await tabIntoFilter(page, 'coloursCombobox');
+        await tabIntoFilter(page, 'colours');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option
         await page.keyboard.press('Space'); // Press `Space` to check option "Black"
@@ -236,6 +240,7 @@ test.describe('ADG-Combobox (single)', () => {
         await expectSingleCombobox(page, {
           filterFocused: true,
           filterValue: 'Black',
+          filterTerm: '',
           optionsExpanded: false,
           selectedOptions: ['Black'],
         });
@@ -244,6 +249,7 @@ test.describe('ADG-Combobox (single)', () => {
         await expectSingleCombobox(page, {
           unselectAllButtonFocused: true,
           filterValue: 'Black',
+          filterTerm: '',
           optionsExpanded: false,
           selectedOptions: ['Black'],
         });
@@ -258,7 +264,7 @@ test.describe('ADG-Combobox (single)', () => {
     });
 
     test('Propagate Enter key', async ({ page }) => {
-      await tabIntoFilter(page, 'coloursCombobox');
+      await tabIntoFilter(page, 'colours');
       await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
       await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option
       await page.keyboard.press('Space'); // Press `Space` to check option "Black"
@@ -270,13 +276,13 @@ test.describe('ADG-Combobox (single)', () => {
 
   test.describe('Mouse interaction', () => {
     test('Click into filter input', async ({ page }) => {
-      await clickIntoFilter(page, 'coloursCombobox'); // Click into the filter to expand options
+      await clickIntoFilter(page, 'colours'); // Click into the filter to expand options
       await expectSingleCombobox(page, {
         filterFocused: true,
         optionsExpanded: true,
       });
 
-      await clickIntoFilter(page, 'coloursCombobox'); // Click again into the filter, options remain expanded (unsure about that, see https://github.com/NothingAG/adg-components/issues/17)
+      await clickIntoFilter(page, 'colours'); // Click again into the filter, options remain expanded (unsure about that, see https://github.com/NothingAG/adg-components/issues/17)
       await expectSingleCombobox(page, {
         filterFocused: true,
         optionsExpanded: true,
@@ -284,7 +290,7 @@ test.describe('ADG-Combobox (single)', () => {
     });
 
     test('Click out of filter input', async ({ page }) => {
-      await clickIntoFilter(page, 'coloursCombobox'); // Click into the filter to expand options
+      await clickIntoFilter(page, 'colours'); // Click into the filter to expand options
       await expectSingleCombobox(page, {
         filterFocused: true,
         optionsExpanded: true,
@@ -298,13 +304,13 @@ test.describe('ADG-Combobox (single)', () => {
     });
 
     test('Click open/close button', async ({ page }) => {
-      await clickOpenCloseButton(page, 'coloursCombobox'); // Click open/close button to expand options
+      await clickOpenCloseButton(page, 'colours'); // Click open/close button to expand options
       await expectSingleCombobox(page, {
         filterFocused: true,
         optionsExpanded: true,
       });
 
-      await clickOpenCloseButton(page, 'coloursCombobox'); // Click open/close button to collapse options
+      await clickOpenCloseButton(page, 'colours'); // Click open/close button to collapse options
       await expectSingleCombobox(page, {
         filterFocused: true,
         optionsExpanded: false,
@@ -312,21 +318,23 @@ test.describe('ADG-Combobox (single)', () => {
     });
 
     test('Select option', async ({ page }) => {
-      await clickIntoFilter(page, 'coloursCombobox'); // Expand options
-      await clickOption(page, 'Black', 'coloursCombobox'); // Select option "Black"
+      await clickIntoFilter(page, 'colours'); // Expand options
+      await clickOption(page, 'Black', 'colours'); // Select option "Black"
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'Black',
+        filterTerm: '',
         optionsExpanded: false,
         visibleOptions: ALL_SINGLE_OPTIONS.map((i) => i.label),
         selectedOptions: ['Black'],
       });
 
-      await clickIntoFilter(page, 'coloursCombobox'); // Expand options again
-      await clickOption(page, 'Brown', 'coloursCombobox'); // Select option "Brown"
+      await clickIntoFilter(page, 'colours'); // Expand options again
+      await clickOption(page, 'Brown', 'colours'); // Select option "Brown"
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'Brown',
+        filterTerm: '',
         optionsExpanded: false,
         visibleOptions: ALL_SINGLE_OPTIONS.map((i) => i.label),
         selectedOptions: ['Brown'],
@@ -336,7 +344,7 @@ test.describe('ADG-Combobox (single)', () => {
 
   test.describe('Filter', () => {
     test('Change filter term to expand options', async ({ page }) => {
-      await tabIntoFilter(page, 'coloursCombobox'); // Focus filter term (does not expand options)
+      await tabIntoFilter(page, 'colours'); // Focus filter term (does not expand options)
       await expectSingleCombobox(page, {
         filterFocused: true,
         optionsExpanded: false,
@@ -346,25 +354,28 @@ test.describe('ADG-Combobox (single)', () => {
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'b',
+        filterTerm: 'b',
         visibleOptions: ['Black', 'Blue', 'Brown'],
         optionsExpanded: true,
       });
     });
 
     test('Enter term to filter options', async ({ page }) => {
-      await clickIntoFilter(page, 'coloursCombobox'); // Expand options
+      await clickIntoFilter(page, 'colours'); // Expand options
       await page.keyboard.press('b'); // Start filtering with "b"
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'b',
+        filterTerm: 'b',
         visibleOptions: ['Black', 'Blue', 'Brown'],
         optionsExpanded: true,
       });
 
-      await page.keyboard.press('l'); // Add "a", so filter is "bl"
+      await page.keyboard.press('l'); // Add "l", so filter is "bl"
       await expectSingleCombobox(page, {
         filterFocused: true,
-        filterValue: 'ba',
+        filterValue: 'bl',
+        filterTerm: 'bl',
         visibleOptions: ['Black', 'Blue'],
         optionsExpanded: true,
       });
@@ -373,17 +384,19 @@ test.describe('ADG-Combobox (single)', () => {
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'blx',
+        filterTerm: 'blx',
         visibleOptions: [],
         optionsExpanded: true,
       });
     });
 
     test('Toggle through filtered options', async ({ page }) => {
-      await clickIntoFilter(page, 'coloursCombobox'); // Expand options
+      await clickIntoFilter(page, 'colours'); // Expand options
       await page.keyboard.press('b'); // Start filtering with "b"
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'b',
+        filterTerm: 'b',
         visibleOptions: ['Black', 'Blue', 'Brown'],
         optionsExpanded: true,
       });
@@ -391,6 +404,7 @@ test.describe('ADG-Combobox (single)', () => {
       await page.keyboard.press('ArrowDown'); // Move focus to first option "Black"
       await expectSingleCombobox(page, {
         filterValue: 'b',
+        filterTerm: 'b',
         visibleOptions: ['Black', 'Blue', 'Brown'],
         focusedOption: 'Black',
         optionsExpanded: true,
@@ -400,6 +414,7 @@ test.describe('ADG-Combobox (single)', () => {
       await page.keyboard.press('ArrowDown'); // Move focus to next (last) option "Brown"
       await expectSingleCombobox(page, {
         filterValue: 'b',
+        filterTerm: 'b',
         visibleOptions: ['Black', 'Blue', 'Brown'],
         focusedOption: 'Brown',
         optionsExpanded: true,
@@ -409,6 +424,7 @@ test.describe('ADG-Combobox (single)', () => {
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'b',
+        filterTerm: 'b',
         visibleOptions: ['Black', 'Blue', 'Brown'],
         optionsExpanded: true,
       });
@@ -417,11 +433,12 @@ test.describe('ADG-Combobox (single)', () => {
     test('Filter can be changed while toggling through options', async ({
       page,
     }) => {
-      await clickIntoFilter(page, 'coloursCombobox'); // Expand options
+      await clickIntoFilter(page, 'colours'); // Expand options
       await page.keyboard.press('l'); // Start filtering with "a"
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'l',
+        filterTerm: 'l',
         visibleOptions: ['Black', 'Blue', 'Yellow'],
         optionsExpanded: true,
       });
@@ -429,6 +446,7 @@ test.describe('ADG-Combobox (single)', () => {
       await page.keyboard.press('ArrowDown'); // Move focus to first option "Black"
       await expectSingleCombobox(page, {
         filterValue: 'l',
+        filterTerm: 'l',
         visibleOptions: ['Black', 'Blue', 'Yellow'],
         optionsExpanded: true,
         focusedOption: 'Black',
@@ -438,6 +456,7 @@ test.describe('ADG-Combobox (single)', () => {
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'la',
+        filterTerm: 'la',
         visibleOptions: ['Black'],
         optionsExpanded: true,
       });
@@ -445,6 +464,7 @@ test.describe('ADG-Combobox (single)', () => {
       await page.keyboard.press('ArrowDown'); // Move focus to first option "Black"
       await expectSingleCombobox(page, {
         filterValue: 'la',
+        filterTerm: 'la',
         visibleOptions: ['Black'],
         optionsExpanded: true,
         focusedOption: 'Black',
@@ -454,6 +474,7 @@ test.describe('ADG-Combobox (single)', () => {
       await expectSingleCombobox(page, {
         filterFocused: true,
         filterValue: 'lax',
+        filterTerm: 'lax',
         visibleOptions: [],
         optionsExpanded: true,
       });


### PR DESCRIPTION
Some test internals were commented out due to bug #25. As this was fixed, I took the opportunity to uncomment those parts and refactor the tests a bit, to allow them to more specifically differentiate between single and multi selects. Those differences are subtle, but important for what screen readers output.

![CleanShot 2022-04-30 at 13 13 28@2x](https://user-images.githubusercontent.com/1814983/166103226-297b668f-8cc4-4cf9-a3de-9191b2a485e8.png)
