### PR TITLE
Rename button "unselect all" to "clear selection"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following events will be fired upon interaction with a combobox:
 | Event                   | Description                                                                                                              |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `optionChanged`         | Fired when an option is selected or unselected. See `event.detail.value` and `event.detail.selected` for details.        |
-| `allOptionsUnselected`  | Fired when all options are unselected.                                                                                   |
+| `selectionCleared`      | Fired when all selection was cleared.                                                                                    |
 | `filterTermChanged`     | Fired when the filter term was changed. See `event.detail.previousFilterTerm` and `event.detail.filterText` for details. |
 | `optionsDropdownOpened` | Fired when options were opened.                                                                                          |
 | `optionsDropdownClosed` | Fired when options were closed.                                                                                          |

--- a/packages/adg-components/src/components.d.ts
+++ b/packages/adg-components/src/components.d.ts
@@ -34,11 +34,11 @@ declare namespace LocalJSX {
         "label"?: string;
         "multi"?: boolean;
         "name"?: string;
-        "onAllOptionsUnselected"?: (event: CustomEvent<never>) => void;
         "onFilterTermChanged"?: (event: CustomEvent<AdgComboboxFilterTermChange>) => void;
         "onOptionChanged"?: (event: CustomEvent<AdgComboboxOptionChange>) => void;
         "onOptionsDropdownClosed"?: (event: CustomEvent<never>) => void;
         "onOptionsDropdownOpened"?: (event: CustomEvent<never>) => void;
+        "onSelectionCleared"?: (event: CustomEvent<never>) => void;
         "options"?: Option[];
         "roleAlert"?: boolean;
         "value"?: string[] | string;

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.i18n.de.json
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.i18n.de.json
@@ -6,5 +6,6 @@
   "results": "$(optionsTotal) $(filterlabel)",
   "results_selected": "$(filterlabel) gewählt: ",
   "results_filtered": "$(optionsShown) von $(optionsTotal) $(filterlabel) für Filter \"$(filterTerm)\"",
-  "results_first": "beginnend mit \"$(first)\""
+  "results_first": "beginnend mit \"$(first)\"",
+  "clear_selection": "Auswahl löschen"
 }

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.i18n.en.json
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.i18n.en.json
@@ -6,5 +6,6 @@
   "results": "$(optionsTotal) $(filterlabel)",
   "results_selected": "$(filterlabel) selected: ",
   "results_filtered": "$(optionsShown) of $(optionsTotal) $(filterlabel) for filter \"$(filterTerm)\"",
-  "results_first": "starting with \"$(first)\""
+  "results_first": "starting with \"$(first)\"",
+  "clear_selection": "clear selection"
 }

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.scss
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.scss
@@ -46,7 +46,7 @@
   outline: 1px solid red;
 }
 
-.adg-combobox--unselect-all-button {
+.adg-combobox--clear-selection-button {
   position: absolute;
   border: 0;
   background-color: transparent;
@@ -63,7 +63,7 @@
   padding-left: 4px;
 }
 
-.adg-combobox--unselect-all-button {
+.adg-combobox--clear-selection-button {
   img {
     vertical-align: middle;
   }

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
@@ -35,7 +35,7 @@ export class AdgComboboxComponent {
   lastArrowSelectedElem = 0;
 
   filterInputElementRef: HTMLInputElement;
-  unselectAllButtonElementRef: HTMLButtonElement;
+  selectionClearedButtonElementRef: HTMLButtonElement;
   fieldsetElementRef: HTMLFieldSetElement;
   filterAndOptionsContainerElementRef: HTMLSpanElement;
 
@@ -82,7 +82,7 @@ export class AdgComboboxComponent {
   }
 
   @Event() optionChanged: EventEmitter<AdgComboboxOptionChange>;
-  @Event() allOptionsUnselected: EventEmitter<never>;
+  @Event() selectionCleared: EventEmitter<never>;
   @Event() filterTermChanged: EventEmitter<AdgComboboxFilterTermChange>;
   @Event() optionsDropdownOpened: EventEmitter<never>;
   @Event() optionsDropdownClosed: EventEmitter<never>;
@@ -170,7 +170,7 @@ export class AdgComboboxComponent {
     );
   }
 
-  handleUnselectAllButtonClick() {
+  handleSelectionClearedButtonClick() {
     const selectedOptionValues = this.selectedOptionModels.map(
       ({ value }) => value
     );
@@ -181,7 +181,7 @@ export class AdgComboboxComponent {
     selectedOptionValues.forEach((value) =>
       this.optionChanged.emit({ value, selected: false })
     );
-    this.allOptionsUnselected.emit();
+    this.selectionCleared.emit();
     this.setInputValue('');
   }
 
@@ -418,10 +418,10 @@ export class AdgComboboxComponent {
             />
           </span>
           <button
-            class="adg-combobox--unselect-all-button"
+            class="adg-combobox--clear-selection-button"
             type="button"
-            ref={(el) => (this.unselectAllButtonElementRef = el)}
-            onClick={() => this.handleUnselectAllButtonClick()}
+            ref={(el) => (this.selectionClearedButtonElementRef = el)}
+            onClick={() => this.handleSelectionClearedButtonClick()}
             hidden={this.selectedOptionModels.length === 0}
           >
             <span id={this._optionsSelectedId}>
@@ -440,7 +440,7 @@ export class AdgComboboxComponent {
                 ,
               </span>
             </span>
-            <img src={getAssetPath(`./assets/clear.svg`)} alt="unselect all" />
+            <img src={getAssetPath(`./assets/clear.svg`)} alt="clear selection" />
           </button>
           <button
             class="adg-combobox--toggle-options-button"

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
@@ -440,7 +440,7 @@ export class AdgComboboxComponent {
                 ,
               </span>
             </span>
-            <img src={getAssetPath(`./assets/clear.svg`)} alt="clear selection" />
+            <img src={getAssetPath(`./assets/clear.svg`)} alt={this.$t('clear_selection')} />
           </button>
           <button
             class="adg-combobox--toggle-options-button"

--- a/packages/adg-components/src/index.html
+++ b/packages/adg-components/src/index.html
@@ -100,7 +100,7 @@
       let eventCounter = 1;
       let events = document.querySelector('#events');
       [hobbies, colours].forEach((combobox) => {
-        ['optionChanged', 'allOptionsUnselected', 'filterTermChanged', 'optionsDropdownOpened', 'optionsDropdownClosed'].forEach((eventName) => {
+        ['optionChanged', 'selectionCleared', 'filterTermChanged', 'optionsDropdownOpened', 'optionsDropdownClosed'].forEach((eventName) => {
           combobox.addEventListener(eventName, (event) => {
             events.innerHTML += `<p>${eventCounter}: ${eventName}, ${JSON.stringify(event.detail)}</p>`;
             eventCounter++;

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -38,7 +38,7 @@ interface ComboboxExpectations {
   visibleOptions?: string[];
   focusedOption?: string;
   selectedOptions?: string[];
-  unselectAllButtonFocused?: boolean;
+  selectionClearedButtonFocused?: boolean;
 }
 
 export const expectSingleCombobox = async (
@@ -66,7 +66,7 @@ export const expectSingleCombobox = async (
       visibleOptions: ALL_SINGLE_OPTIONS.map((i) => i.label),
       focusedOption: null,
       selectedOptions: [],
-      unselectAllButtonFocused: false,
+      selectionClearedButtonFocused: false,
     },
     expectations
   );
@@ -102,7 +102,7 @@ export const expectMultiCombobox = async (
       visibleOptions: ALL_MULTI_OPTIONS.map((i) => i.label),
       focusedOption: null,
       selectedOptions: [],
-      unselectAllButtonFocused: false,
+      selectionClearedButtonFocused: false,
     },
     expectations
   );
@@ -135,7 +135,7 @@ export const expectCombobox = async (
     visibleOptions,
     focusedOption,
     selectedOptions,
-    unselectAllButtonFocused,
+    selectionClearedButtonFocused,
   } = expectations;
 
   const filterInputId = `${options.internalId}--filter`;
@@ -191,34 +191,36 @@ export const expectCombobox = async (
     xOptionsSelectedId
   );
 
-  const unselectAllButton = filterAndOptionsContainer.locator(
-    'button.adg-combobox--unselect-all-button'
+  const selectionClearedButton = filterAndOptionsContainer.locator(
+    'button.adg-combobox--clear-selection-button'
   );
-  await expect(unselectAllButton).toHaveAttribute('type', 'button');
-  await expect(unselectAllButton).toHaveAttribute('hidden', '');
+  await expect(selectionClearedButton).toHaveAttribute('type', 'button');
+  await expect(selectionClearedButton).toHaveAttribute('hidden', '');
 
-  if (unselectAllButtonFocused) {
-    await expect(unselectAllButton).toBeFocused();
+  if (selectionClearedButtonFocused) {
+    await expect(selectionClearedButton).toBeFocused();
   } else {
-    await expect(unselectAllButton).not.toBeFocused();
+    await expect(selectionClearedButton).not.toBeFocused();
   }
 
   if (options.multi) {
     // TODO: When there is no option selected, then there should be no colon and no comma!
-    await expect(unselectAllButton).toHaveText(
+    await expect(selectionClearedButton).toHaveText(
       `${selectedOptions.length} ${
         options.filterlabel
       } selected: ${selectedOptions.join(', ')},`
     );
   } else {
-    await expect(unselectAllButton).toHaveText(
+    await expect(selectionClearedButton).toHaveText(
       `${options.filterlabel} ${
         options.multi ? 'selected' : 'gewählt'
       }: ${selectedOptions.join(', ')},`
     );
   }
 
-  const xOptionsSelected = unselectAllButton.locator(`#${xOptionsSelectedId}`);
+  const xOptionsSelected = selectionClearedButton.locator(
+    `#${xOptionsSelectedId}`
+  );
   const xSelectedCount = xOptionsSelected.locator(
     '.adg-combobox--x-selected-count'
   );
@@ -249,10 +251,13 @@ export const expectCombobox = async (
     await expect(xSelectedLabels).toHaveText(selectedOptions.join(', '));
   }
 
-  const unselectAllButtonImage = unselectAllButton.locator(
+  const selectionClearedButtonImage = selectionClearedButton.locator(
     'img[src$="clear.svg"]'
   );
-  await expect(unselectAllButtonImage).toHaveAttribute('alt', 'unselect all');
+  await expect(selectionClearedButtonImage).toHaveAttribute(
+    'alt',
+    'clear selection'
+  );
 
   const toggleOptionsButton = filterAndOptionsContainer.locator(
     'button.adg-combobox--toggle-options-button'

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -256,7 +256,7 @@ export const expectCombobox = async (
   );
   await expect(selectionClearedButtonImage).toHaveAttribute(
     'alt',
-    'clear selection'
+    options.multi ? 'clear selection' : 'Auswahl löschen'
   );
 
   const toggleOptionsButton = filterAndOptionsContainer.locator(

--- a/tests/multiselect.spec.ts
+++ b/tests/multiselect.spec.ts
@@ -234,27 +234,27 @@ test.describe('ADG-Combobox (multi)', () => {
       });
     });
 
-    test.describe('Activate "Unselect all" button', () => {
+    test.describe('Activate "Clear selection" button', () => {
       test('With empty filter', async ({ page }) => {
         await tabIntoFilter(page, 'hobbies');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
         await page.keyboard.press('ArrowDown'); // Press `Down` to set focus on first option
         await page.keyboard.press('Space'); // Press `Space` to check option "Soccer"
-        await page.keyboard.press('Escape'); // Press `Esc` to collapse options and set focus to "Unselect all" button
+        await page.keyboard.press('Escape'); // Press `Esc` to collapse options and set focus to "Clear Selection" button
         await expectMultiCombobox(page, {
           filterFocused: true,
           optionsExpanded: false,
           selectedOptions: ['Soccer'],
         });
 
-        await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Unselect all" button
+        await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Clear Selection" button
         await expectMultiCombobox(page, {
-          unselectAllButtonFocused: true,
+          selectionClearedButtonFocused: true,
           optionsExpanded: false,
           selectedOptions: ['Soccer'],
         });
 
-        await page.keyboard.press('Enter'); // Press `Enter` to activate "Unselect all" button
+        await page.keyboard.press('Enter'); // Press `Enter` to activate "Clear Selection" button
         await expectMultiCombobox(page, {
           filterFocused: true,
           optionsExpanded: true,
@@ -283,16 +283,16 @@ test.describe('ADG-Combobox (multi)', () => {
           visibleOptions: ['Badminton', 'Kickboxing'],
         });
 
-        await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Unselect all" button
+        await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Clear Selection" button
         await expectMultiCombobox(page, {
-          unselectAllButtonFocused: true,
+          selectionClearedButtonFocused: true,
           filterValue: 'b',
           optionsExpanded: false,
           selectedOptions: ['Badminton'],
           visibleOptions: ['Badminton', 'Kickboxing'],
         });
 
-        await page.keyboard.press('Enter'); // Press `Enter` to activate "Unselect all" button
+        await page.keyboard.press('Enter'); // Press `Enter` to activate "Clear Selection" button
         await expectMultiCombobox(page, {
           filterFocused: true,
           optionsExpanded: true,
@@ -561,19 +561,19 @@ test.describe('ADG-Combobox (multi)', () => {
       );
     });
 
-    test('Event allOptionsUnselected is fired upon activating "Unselect all" button', async ({
+    test('Event selectionCleared is fired upon activating "Clear Selection" button', async ({
       page,
     }) => {
       await clickIntoFilter(page, 'hobbies'); // Click into the filter to expand options
       await clickOption(page, 'Soccer', 'hobbies'); // Select option "Black"
       await page.keyboard.press('Escape'); // Press `Escape` to move focus back to filter term
-      await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Unselect all" button
-      await page.keyboard.press('Enter'); // Press `Enter` to activate "Unselect all" button
+      await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Clear Selection" button
+      await page.keyboard.press('Enter'); // Press `Enter` to activate "Clear Selection" button
       await expect(page.locator('#events p:nth-child(4)')).toHaveText(
         '4: optionChanged, {"value":"soccer","selected":false}'
       );
       await expect(page.locator('#events p:nth-child(5)')).toHaveText(
-        '5: allOptionsUnselected, null'
+        '5: selectionCleared, null'
       );
     });
 

--- a/tests/singleselect.spec.ts
+++ b/tests/singleselect.spec.ts
@@ -230,7 +230,7 @@ test.describe('ADG-Combobox (single)', () => {
       });
     });
 
-    test.describe('Activate "Unselect all" button', () => {
+    test.describe('Activate "Clear Selection" button', () => {
       test('With empty filter', async ({ page }) => {
         await tabIntoFilter(page, 'colours');
         await page.keyboard.press('ArrowDown'); // Press `Down` to expand options
@@ -245,16 +245,16 @@ test.describe('ADG-Combobox (single)', () => {
           selectedOptions: ['Black'],
         });
 
-        await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Unselect all" button
+        await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Clear Selection" button
         await expectSingleCombobox(page, {
-          unselectAllButtonFocused: true,
+          selectionClearedButtonFocused: true,
           filterValue: 'Black',
           filterTerm: '',
           optionsExpanded: false,
           selectedOptions: ['Black'],
         });
 
-        await page.keyboard.press('Enter'); // Press `Enter` to activate "Unselect all" button
+        await page.keyboard.press('Enter'); // Press `Enter` to activate "Clear Selection" button
         await expectSingleCombobox(page, {
           filterFocused: true,
           optionsExpanded: true,
@@ -285,9 +285,9 @@ test.describe('ADG-Combobox (single)', () => {
           visibleOptions: ['Black', 'Orange'],
         });
 
-        await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Unselect all" button
+        await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Clear Selection" button
         await expectSingleCombobox(page, {
-          unselectAllButtonFocused: true,
+          selectionClearedButtonFocused: true,
           filterValue: 'Black',
           filterTerm: 'a',
           optionsExpanded: false,
@@ -295,7 +295,7 @@ test.describe('ADG-Combobox (single)', () => {
           visibleOptions: ['Black', 'Orange'],
         });
 
-        await page.keyboard.press('Enter'); // Press `Enter` to activate "Unselect all" button
+        await page.keyboard.press('Enter'); // Press `Enter` to activate "Clear Selection" button
         await expectSingleCombobox(page, {
           filterFocused: true,
           optionsExpanded: true,
@@ -579,18 +579,18 @@ test.describe('ADG-Combobox (single)', () => {
       );
     });
 
-    test('Events optionChanged(selected: false) and allOptionsUnselected are fired upon activating "Unselect all" button', async ({
+    test('Events optionChanged(selected: false) and selectionCleared are fired upon activating "Clear Selection" button', async ({
       page,
     }) => {
       await clickIntoFilter(page, 'colours'); // Click into the filter to expand options
       await clickOption(page, 'Black', 'colours'); // Select option "Black"
-      await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Unselect all" button
-      await page.keyboard.press('Enter'); // Press `Enter` to activate "Unselect all" button
+      await page.keyboard.press('Tab'); // Press `Tab` to move focus to "Clear Selection" button
+      await page.keyboard.press('Enter'); // Press `Enter` to activate "Clear Selection" button
       await expect(page.locator('#events p:nth-child(4)')).toHaveText(
         '4: optionChanged, {"value":"000000","selected":false}'
       );
       await expect(page.locator('#events p:nth-child(5)')).toHaveText(
-        '5: allOptionsUnselected, null'
+        '5: selectionCleared, null'
       );
     });
 

--- a/tests/widget-tests3.txt
+++ b/tests/widget-tests3.txt
@@ -130,18 +130,18 @@ DESCRIBE ADG Combobox
       SPECIFY Tab out of filter input
         // Still unclear of the optimal interplay of browser default behaviour and keyboard-only optimisations, see https://github.com/NothingAG/adg-components/issues/8 and https://github.com/NothingAG/adg-components/issues/16.
 
-      SPECIFY Activate "unselect all" button
+      SPECIFY Activate "Clear Selection" button
         tab_into_filter()
         press("Down") // Displays options
         press("Space") // Selects an option
         press("Esc") // Close options and moves focus to filter input
-        press("Esc") // Moves focus to "unselect all" button
+        press("Esc") // Moves focus to "Clear Selection" button
         has_multi_state(unselect_all_button_focused: true,
                         selected_options: ["Badminton"])
         press("Enter")
         has_multi_state(filter_input_focused: true)
 
-        // TODO: currently, the "unselect all" button is also reachable by Tab. But we are not yet sure whether this will remain, see https://github.com/NothingAG/adg-components/issues/16
+        // TODO: currently, the "Clear Selection" button is also reachable by Tab. But we are not yet sure whether this will remain, see https://github.com/NothingAG/adg-components/issues/16
 
       SPECIFY Propagate Enter key
         // TODO: When filter input is focused, the options are closed, and Enter is pressed, then the form should be submitted.
@@ -167,7 +167,7 @@ DESCRIBE ADG Combobox
       SPECIFY Click open/close button
         // TODO
 
-      SPECIFY Click "unselect all" button
+      SPECIFY Click "Clear Selection" button
         // TODO
 
       SPECIFY Toggle options
@@ -249,7 +249,7 @@ DESCRIBE ADG Combobox
           
         // TODO: More edge cases to test here, but not 100% sure how to handle them yet, see https://github.com/NothingAG/adg-components/issues/13.
 
-    DESCRIBE Click "unselect all" button
+    DESCRIBE Click "Clear Selection" button
       // TODO: Unsure whether we need a specific click-test for this... Doesn't the keyboard-test suffice?
 
     DESCRIBE Pills


### PR DESCRIPTION
For multi selects, a button "unselect all" makes sense. But for single selects, it does not.

I renamed it to "clear selection" to make it fit for both situations. I also added it to the translations (wasn't translated yet).