### PR TITLE
Use adg--visually-hidden, not adg-visually hidden (two dashes)

### DIFF
--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
@@ -430,7 +430,7 @@ export class AdgComboboxComponent {
                   {this.selectedOptionModels.length}&nbsp;
                 </span>
               ) : null}
-              <span class="adg-visually-hidden">
+              <span class="adg--visually-hidden">
                 {this.$t('results_selected', {
                   filterlabel: this.filterlabel,
                 })}
@@ -463,7 +463,7 @@ export class AdgComboboxComponent {
             onKeyUp={(ev) => this.handleKeyUpForPageUpAndPageDown(ev)}
           >
             <legend class="adg-combobox--available-options-legend">
-              <span class="adg-visually-hidden">
+              <span class="adg--visually-hidden">
                 {this.$t('results_title', {
                   filterlabel: this.filterlabel,
                 })}
@@ -483,7 +483,7 @@ export class AdgComboboxComponent {
                 })}
 
                 {!!this.filteredOptionsStartingWith ? (
-                  <span class="adg-visually-hidden">
+                  <span class="adg--visually-hidden">
                     ,{' '}
                     {this.$t('results_first', {
                       first: this.filteredOptionsStartingWith,
@@ -525,7 +525,7 @@ export class AdgComboboxComponent {
 
         {this.multi ? (
           <fieldset class="adg-combobox--selected-options-container">
-            <legend class="adg-visually-hidden">
+            <legend class="adg--visually-hidden">
               {this.$t('results_selected', {
                 filterlabel: this.filterlabel,
               })}

--- a/packages/adg-components/src/styles/base.scss
+++ b/packages/adg-components/src/styles/base.scss
@@ -1,3 +1,3 @@
-.adg-visually-hidden {
+.adg--visually-hidden {
   @include visually-hidden;
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -231,7 +231,7 @@ export const expectCombobox = async (
   }
 
   const xOptionSelectedVisuallyHidden = xOptionsSelected.locator(
-    'span.adg-visually-hidden'
+    'span.adg--visually-hidden'
   );
 
   await expect(xOptionSelectedVisuallyHidden).toHaveText(
@@ -331,7 +331,7 @@ export const expectCombobox = async (
   }
 
   const availableOptionsContainerLegendVisuallyHidden =
-    availableOptionsContainerLegend.locator('> span.adg-visually-hidden');
+    availableOptionsContainerLegend.locator('> span.adg--visually-hidden');
   await expect(availableOptionsContainerLegendVisuallyHidden).toHaveText(
     `${options.multi ? 'Available' : 'Verfügbare'} ${options.filterlabel}:`
   );


### PR DESCRIPTION
- `adg-visually hidden` (before)
- `adg--visually-hidden` (after)

This marks a clear `adg` namespace, where we can put general things that are used in different components (ie. `adg-combobox`, `adg-tabs`, `adg-whatever`). Using `adg-visually-hidden` might confuse it with another component.