### PR TITLE
Visual enhancements

### DIFF
--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.i18n.de.json
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.i18n.de.json
@@ -4,7 +4,7 @@
   "open": "$(filterlabel) Auswahl öffnen",
   "results_title": "Verfügbare $(filterlabel)",
   "results": "$(optionsTotal) $(filterlabel)",
-  "results_selected": "$(filterlabel) gewählt: ",
+  "results_selected": "Gewählte $(filterlabel): ",
   "results_filtered": "$(optionsShown) von $(optionsTotal) $(filterlabel) für Filter \"$(filterTerm)\"",
   "results_first": "beginnend mit \"$(first)\"",
   "clear_selection": "Auswahl löschen"

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.i18n.en.json
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.i18n.en.json
@@ -4,7 +4,7 @@
   "open": "Open $(filterlabel) Options",
   "results_title": "Available $(filterlabel)",
   "results": "$(optionsTotal) $(filterlabel)",
-  "results_selected": "$(filterlabel) selected: ",
+  "results_selected": "Selected $(filterlabel): ",
   "results_filtered": "$(optionsShown) of $(optionsTotal) $(filterlabel) for filter \"$(filterTerm)\"",
   "results_first": "starting with \"$(first)\"",
   "clear_selection": "clear selection"

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.scss
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.scss
@@ -191,12 +191,43 @@
     padding: 2 4px;
     width: 100%;
     box-sizing: border-box;
-    border-left: 4px solid transparent;
 
-    /* For high contrast mode */
+    .adg-combobox--multi & {
+      padding-left: 0.25em;
+    }
+
+    /* For high contrast mode: we need a visual cue! */
+    border-left: 4px solid transparent;
   }
 
   input {
+    margin-left: 0;
+    margin-right: 0;
+
+    + span {
+      margin-left: .25em;
+    }
+
+    &:checked {
+      + span {
+        font-weight: bold;
+    
+        .check {
+          .adg-combobox--multi & {
+            display: none;
+          }
+
+          content: ' ';
+          display: inline-block;
+          margin-left: 0.25em;
+          background-color: red;
+          width: 14px;
+          height: 14px;
+          background: url(./build/assets/check.svg);
+        }
+      }
+    }
+
     .adg-combobox--single & {
       @include visually-hidden
     }
@@ -215,20 +246,6 @@
       background-color: rgb(255, 167, 167);
       cursor: pointer;
       border-left-color: #000;
-    }
-  }
-
-  input:checked + span {
-    font-weight: bold;
-
-    .check {
-      content: ' ';
-      display: inline-block;
-      margin-left: 0.25em;
-      background-color: red;
-      width: 14px;
-      height: 14px;
-      background: url(./build/assets/check.svg);
     }
   }
 }

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.scss
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.scss
@@ -202,6 +202,10 @@
   }
 
   input {
+    .adg-combobox--single & {
+      @include visually-hidden
+    }
+
     &:focus {
       outline: none;
     }

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.scss
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.scss
@@ -1,10 +1,5 @@
 .adg-combobox--filter-label {
   display: inline-block;
-  width: 100px;
-
-  &::after {
-    content: ':';
-  }
 }
 
 .adg-combobox--filter-input {

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
@@ -386,7 +386,7 @@ export class AdgComboboxComponent {
             htmlFor={this._inputId}
             class="adg-combobox--filter-label"
           >
-            {this.label}
+            {this.label}:&nbsp;
           </label>
         ) : null}
         <span

--- a/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
+++ b/packages/adg-components/src/components/adg-combobox/adg-combobox.tsx
@@ -380,7 +380,7 @@ export class AdgComboboxComponent {
 
   render() {
     return (
-      <Host onKeyDown={(ev) => this.handleKeyDown(ev)} class="adg-combobox">
+      <Host onKeyDown={(ev) => this.handleKeyDown(ev)} class={`adg-combobox adg-combobox--${this.multi ? 'multi' : 'single'}`}>
         {this.label ? (
           <label
             htmlFor={this._inputId}

--- a/packages/adg-components/src/index.html
+++ b/packages/adg-components/src/index.html
@@ -12,6 +12,10 @@
       form {
         margin: 0;
       }
+
+      #events {
+        font-size: 0.5em;
+      }
     </style>
 
     <script type="module" src="/build/adg-components.esm.js"></script>

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -145,7 +145,7 @@ export const expectCombobox = async (
 
   const filterlabel = combobox.locator('label.adg-combobox--filter-label');
   if (options.label) {
-    await expect(filterlabel).toHaveText(options.label);
+    await expect(filterlabel).toHaveText(`${options.label}:`);
     await expect(filterlabel).toHaveAttribute('for', filterInputId);
     await expect(filterlabel).toHaveCSS('display', 'inline-block'); // So label and filter input are read "in one go" in most screen readers => TODO: factor out into custom matcher, ie. `toNotIntroduceSemanticLineBreak`!
   }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -206,14 +206,14 @@ export const expectCombobox = async (
   if (options.multi) {
     // TODO: When there is no option selected, then there should be no colon and no comma!
     await expect(selectionClearedButton).toHaveText(
-      `${selectedOptions.length} ${
+      `${selectedOptions.length} Selected ${
         options.filterlabel
-      } selected: ${selectedOptions.join(', ')},`
+      }: ${selectedOptions.join(', ')},`
     );
   } else {
     await expect(selectionClearedButton).toHaveText(
-      `${options.filterlabel} ${
-        options.multi ? 'selected' : 'gewählt'
+      `${options.multi ? 'Selected' : 'Gewählte'} ${
+        options.filterlabel
       }: ${selectedOptions.join(', ')},`
     );
   }
@@ -235,8 +235,8 @@ export const expectCombobox = async (
   );
 
   await expect(xOptionSelectedVisuallyHidden).toHaveText(
-    `${options.filterlabel} ${
-      options.multi ? 'selected' : 'gewählt'
+    `${options.multi ? 'Selected' : 'Gewählte'} ${
+      options.filterlabel
     }: ${selectedOptions.join(', ')},`
   );
   // TODO: No colon, no comma!


### PR DESCRIPTION
I removed the "check" mark next to multi select options (the `<input type="checkbox">` already indicates the state):

Before:

![CleanShot 2022-05-03 at 10 14 02@2x](https://user-images.githubusercontent.com/1814983/166422665-d4d92715-b15a-40ba-a932-291ffe4693a8.png)

After:

![CleanShot 2022-05-03 at 10 17 01@2x](https://user-images.githubusercontent.com/1814983/166422889-1aa043cc-c79c-428d-8b36-fd07079f6f3d.png)

I also visually hid the `<input type="radio">` in the single select options:

Before:

![CleanShot 2022-05-03 at 10 16 16@2x](https://user-images.githubusercontent.com/1814983/166422824-949ff864-c3f5-4433-a9fb-46f1f0107e70.png)

After:

![CleanShot 2022-05-03 at 10 17 24@2x](https://user-images.githubusercontent.com/1814983/166422937-7523c58f-0f8f-47bc-b0af-ca5214309134.png)

Tests all passing:

![CleanShot 2022-05-03 at 10 18 25@2x](https://user-images.githubusercontent.com/1814983/166423042-551082ba-a12d-41d4-b384-13cfb496c57a.png)
